### PR TITLE
Added cancelLabel attribute to generic type forms

### DIFF
--- a/Type/Extension/GenericTypeExtension.php
+++ b/Type/Extension/GenericTypeExtension.php
@@ -17,6 +17,7 @@ class GenericTypeExtension extends AbstractTypeExtension
     {
         $builder->setAttribute('help', $options['help']);
         $builder->setAttribute('cancelUrl', $options['cancelUrl']);
+        $builder->setAttribute('cancelLabel', $options['cancelLabel']);
     }
 
 
@@ -26,8 +27,9 @@ class GenericTypeExtension extends AbstractTypeExtension
      */
     public function buildView (FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['cancelUrl'] = $form->getConfig()->getAttribute('cancelUrl');
-        $view->vars['help']      = $form->getConfig()->getAttribute('help');
+        $view->vars['cancelUrl']   = $form->getConfig()->getAttribute('cancelUrl');
+        $view->vars['cancelLabel'] = $form->getConfig()->getAttribute('cancelLabel');
+        $view->vars['help']        = $form->getConfig()->getAttribute('help');
     }
 
 
@@ -38,8 +40,9 @@ class GenericTypeExtension extends AbstractTypeExtension
     public function setDefaultOptions (OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults([
-            'help'      => null,
-            'cancelUrl' => null,
+            'help'        => null,
+            'cancelUrl'   => null,
+            'cancelLabel' => null,
         ]);
     }
 


### PR DESCRIPTION
This change adds support for a new cancelLabel attribute, which is especially useful in i18n environments where the cancel label can't be hardcoded.