### PR TITLE
Added GoogleAnalyticsWrapper as inline script via Twig

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -16,6 +16,13 @@ services:
             - { name: twig.extension }
 
 
+    # Google Analytics
+    becklyn_rad.twig.google_analytics:
+        class: Becklyn\RadBundle\Twig\GoogleAnalyticsTwigExtension
+        tags:
+            - { name: twig.extension }
+
+
     # Security / Authentication
     becklyn_rad.authentication_helper:
         class: Becklyn\RadBundle\Security\AuthenticationHelper

--- a/Twig/GoogleAnalyticsTwigExtension.php
+++ b/Twig/GoogleAnalyticsTwigExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Becklyn\RadBundle\Twig;
+
+
+/**
+ *
+ */
+class GoogleAnalyticsTwigExtension extends AbstractTwigExtension
+{
+    /**
+     * Renders all blocks of code required to initialize Google Analytics tracking
+     *
+     * @param string $trackingCode
+     *
+     * @return string
+     */
+    public function analyticsTracking (string $trackingCode) : string
+    {
+        if (empty($trackingCode))
+        {
+            return "";
+        }
+
+        $analyticsScript = <<<'EOD'
+<script type='text/javascript'>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', '%s', 'auto'); ga('set', 'anonymizeIp', true); ga('send', 'pageview');
+</script>
+EOD;
+
+        return sprintf($analyticsScript, $trackingCode);
+    }
+
+
+    /**
+     * Returns all defined functions
+     *
+     * @return \Twig_SimpleFunction[]
+     */
+    public function getFunctions ()
+    {
+        return [
+            new \Twig_SimpleFunction("analyticsTracking", [$this, "analyticsTracking"], ["is_safe" => ["html"]]),
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds a new Twig extension `analyticsTracking` which you pass your `UA-XXX` Tracking Code that then inlines the necessary Google Analytics scripts right into your page.

One notable change here: I've renamed `window.Becklyn.Google_Analytics` to `window.Becklyn.GoogleAnalytics` to avoid any potential conflicts. This also allows us to call the existing Becklyn GoogleAnalyticsWrapper from outside scripts via `window` globals.