### PR TITLE
Use \DateTimeImmutable in TimestampsTraits

### DIFF
--- a/Entity/Traits/TimestampsTrait.php
+++ b/Entity/Traits/TimestampsTrait.php
@@ -11,14 +11,14 @@ use Doctrine\ORM\Mapping as ORM;
 trait TimestampsTrait
 {
     /**
-     * @var \DateTime
+     * @var \DateTimeImmutable
      * @ORM\Column(name="time_created", type="datetime_immutable")
      */
     private $timeCreated;
 
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeImmutable|null
      * @ORM\Column(name="time_modified", type="datetime_immutable", nullable=true)
      */
     private $timeModified;
@@ -26,9 +26,9 @@ trait TimestampsTrait
 
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeImmutable
      */
-    public function getTimeCreated () : \DateTimeInterface
+    public function getTimeCreated () : \DateTimeImmutable
     {
         return $this->timeCreated;
     }
@@ -36,9 +36,9 @@ trait TimestampsTrait
 
 
     /**
-     * @return \DateTimeInterface|null
+     * @return \DateTimeImmutable|null
      */
-    public function getTimeModified ()
+    public function getTimeModified () : ?\DateTimeImmutable
     {
         return $this->timeModified;
     }
@@ -46,9 +46,9 @@ trait TimestampsTrait
 
 
     /**
-     * @param \DateTime $timeModified
+     * @param \DateTimeImmutable $timeModified
      */
-    public function setTimeModified (\DateTime $timeModified)
+    public function setTimeModified (\DateTimeImmutable $timeModified)
     {
         $this->timeModified = $timeModified;
     }
@@ -58,9 +58,9 @@ trait TimestampsTrait
     /**
      * Returns the most recent modification time
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeImmutable
      */
-    public function getLastModificationTime () : \DateTimeInterface
+    public function getLastModificationTime () : \DateTimeImmutable
     {
         return $this->getTimeModified() ?? $this->getTimeCreated();
     }


### PR DESCRIPTION
With that PR I'd love to release a new stable version containing all changes of the `mayd-era` branch in order to get rid of the `minimum-stability` Composer configuration, unless you've got any more changes that need to go into the next version?