### PR TITLE
Move calculation of pagination offset from `Paginator` to `Pagination`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+7.10.2
+=====
+
+*   (improvement) Move calculation of pagination offset from `Paginator` to `Pagination`.
+
+
 7.10.1
 ======
 

--- a/src/Pagination/Data/Pagination.php
+++ b/src/Pagination/Data/Pagination.php
@@ -135,6 +135,14 @@ class Pagination
 
     /**
      */
+    public function getOffset () : int
+    {
+        return ($this->getCurrentPage() - $this->getMinPage()) * $this->getPerPage();
+    }
+
+
+    /**
+     */
     public function toArray () : array
     {
         return [

--- a/src/Pagination/Paginator.php
+++ b/src/Pagination/Paginator.php
@@ -22,9 +22,8 @@ class Paginator
 
         if ($totalNumberOfItems > 0)
         {
-            $offset = ($newPagination->getCurrentPage() - $newPagination->getMinPage()) * $newPagination->getPerPage();
             $queryBuilder
-                ->setFirstResult($offset)
+                ->setFirstResult($newPagination->getOffset())
                 ->setMaxResults($pagination->getPerPage());
             $list = \iterator_to_array(new DoctrinePaginator($queryBuilder->getQuery()));
         }

--- a/tests/Pagination/Data/PaginationTest.php
+++ b/tests/Pagination/Data/PaginationTest.php
@@ -159,4 +159,18 @@ class PaginationTest extends TestCase
             "valid" => false,
         ], $pagination->toArray());
     }
+
+
+    /**
+     *
+     */
+    public function testCorrectOffsetCalculation () : void
+    {
+        self::assertSame(0, (new Pagination(0, 10, 29))->getOffset());
+        self::assertSame(0, (new Pagination(1, 10, 29))->getOffset());
+        self::assertSame(10, (new Pagination(2, 10, 29))->getOffset());
+        self::assertSame(10, (new Pagination(2, 10, 290))->getOffset());
+        self::assertSame(5, (new Pagination(2, 5, 29))->getOffset());
+        self::assertSame(20, (new Pagination(5, 5, 29))->getOffset());
+    }
 }

--- a/tests/Pagination/Data/PaginationTest.php
+++ b/tests/Pagination/Data/PaginationTest.php
@@ -162,15 +162,24 @@ class PaginationTest extends TestCase
 
 
     /**
-     *
      */
-    public function testCorrectOffsetCalculation () : void
+    public function provideOffset () : iterable
     {
-        self::assertSame(0, (new Pagination(0, 10, 29))->getOffset());
-        self::assertSame(0, (new Pagination(1, 10, 29))->getOffset());
-        self::assertSame(10, (new Pagination(2, 10, 29))->getOffset());
-        self::assertSame(10, (new Pagination(2, 10, 290))->getOffset());
-        self::assertSame(5, (new Pagination(2, 5, 29))->getOffset());
-        self::assertSame(20, (new Pagination(5, 5, 29))->getOffset());
+        yield [0, 0, 10, 0];
+        yield [0, 0, 10, 29];
+        yield [0, 1, 10, 29];
+        yield [10, 2, 10, 29];
+        yield [10, 2, 10, 290];
+        yield [5, 2, 5, 29];
+        yield [20, 5, 5, 29];
+    }
+
+    /**
+     * @dataProvider provideOffset
+     */
+    public function testCorrectOffsetCalculation (int $expected, int $currentPage, int $perPage, int $numberOfItems) : void
+    {
+        $pagination = new Pagination($currentPage, $perPage, $numberOfItems);
+        self::assertSame($expected, $pagination->getOffset());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes<!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |

Move calculation of pagination offset from `Paginator` to `Pagination`
