### PR TITLE
Fix form error translations being in the wrong translation domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+next
+====
+
+*   (bug) Fix form error translations being in the wrong translation domain, so e.g. Gluggi would render an incorrect error message.
+
+
 7.12.0
 ======
 

--- a/src/Resources/translations/form+intl-icu.de.yaml
+++ b/src/Resources/translations/form+intl-icu.de.yaml
@@ -1,0 +1,3 @@
+form:
+    error:
+        message: 'Fehler: {error}'

--- a/src/Resources/translations/form+intl-icu.en.yaml
+++ b/src/Resources/translations/form+intl-icu.en.yaml
@@ -1,0 +1,3 @@
+form:
+    error:
+        message: 'Error: {error}'

--- a/src/Resources/translations/messages+intl-icu.de.yaml
+++ b/src/Resources/translations/messages+intl-icu.de.yaml
@@ -4,6 +4,3 @@ entity_removal:
         generic: Das Löschen ist leider fehlgeschlagen.
         generic_blocked: Der Eintrag kann nicht gelöscht werden, da er noch andernorts referenziert wird.
 
-form:
-    error:
-        message: 'Fehler: {error}'

--- a/src/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Resources/translations/messages+intl-icu.en.yaml
@@ -4,6 +4,3 @@ entity_removal:
         generic: Removing this entry failed.
         generic_blocked: The entry can't be removed, as it is still referenced in another location.
 
-form:
-    error:
-        message: 'Error: {error}'


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                               |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

### Without this change

![image](https://user-images.githubusercontent.com/439899/85901167-7a075380-b801-11ea-9bf2-808386b3a157.png)

### With this change

![image](https://user-images.githubusercontent.com/439899/85901238-9efbc680-b801-11ea-89e1-5e7910c81427.png)
